### PR TITLE
Added support for waiting for other processes

### DIFF
--- a/snapraid-runner.conf.example
+++ b/snapraid-runner.conf.example
@@ -8,6 +8,15 @@ deletethreshold = 40
 ; if you want touch to be ran each time
 touch = false
 
+[wait]
+enabled = false
+delay = 60
+maxdelays = 9
+
+[waitfiles]
+file-1 = wait-for.file
+file-2 = also-wait-for.file
+
 [logging]
 ; logfile to write to, leave empty to disable
 file = snapraid.log


### PR DESCRIPTION
Detect lock files from other processes that are/may be modifying the data disks and wait for them to be removed before continuing with the diff/sync